### PR TITLE
Add SchemaFactory.SCHEMA_LOCATION_URL_CONTEXT property

### DIFF
--- a/src/main/java/io/xlate/edi/internal/schema/SchemaReaderBase.java
+++ b/src/main/java/io/xlate/edi/internal/schema/SchemaReaderBase.java
@@ -90,8 +90,9 @@ abstract class SchemaReaderBase implements SchemaReader {
     final Set<QName> references;
 
     protected XMLStreamReader reader;
+    protected Map<String, Object> properties;
 
-    public SchemaReaderBase(String xmlns, XMLStreamReader reader) {
+    public SchemaReaderBase(String xmlns, XMLStreamReader reader, Map<String, Object> properties) {
         this.xmlns = xmlns;
         qnSchema = new QName(xmlns, "schema");
         qnInclude = new QName(xmlns, "include");
@@ -134,6 +135,7 @@ abstract class SchemaReaderBase implements SchemaReader {
         references.add(qnElement);
 
         this.reader = reader;
+        this.properties = properties;
     }
 
     @Override

--- a/src/main/java/io/xlate/edi/internal/schema/SchemaReaderV2.java
+++ b/src/main/java/io/xlate/edi/internal/schema/SchemaReaderV2.java
@@ -11,8 +11,8 @@ import io.xlate.edi.schema.EDIType;
 
 class SchemaReaderV2 extends SchemaReaderBase implements SchemaReader {
 
-    public SchemaReaderV2(XMLStreamReader reader) {
-        super(StaEDISchemaFactory.XMLNS_V2, reader);
+    public SchemaReaderV2(XMLStreamReader reader, Map<String, Object> properties) {
+        super(StaEDISchemaFactory.XMLNS_V2, reader, properties);
     }
 
     @Override

--- a/src/main/java/io/xlate/edi/internal/schema/SchemaReaderV3.java
+++ b/src/main/java/io/xlate/edi/internal/schema/SchemaReaderV3.java
@@ -73,13 +73,13 @@ class SchemaReaderV3 extends SchemaReaderBase implements SchemaReader {
 
     final ValueSet valueSet = new ValueSet();
 
-    protected SchemaReaderV3(String xmlns, XMLStreamReader reader) {
-        super(xmlns, reader);
+    protected SchemaReaderV3(String xmlns, XMLStreamReader reader, Map<String, Object> properties) {
+        super(xmlns, reader, properties);
         qnImplementation = new QName(xmlns, "implementation");
     }
 
-    public SchemaReaderV3(XMLStreamReader reader) {
-        this(StaEDISchemaFactory.XMLNS_V3, reader);
+    public SchemaReaderV3(XMLStreamReader reader, Map<String, Object> properties) {
+        this(StaEDISchemaFactory.XMLNS_V3, reader, properties);
     }
 
     @Override

--- a/src/main/java/io/xlate/edi/internal/schema/SchemaReaderV4.java
+++ b/src/main/java/io/xlate/edi/internal/schema/SchemaReaderV4.java
@@ -9,11 +9,12 @@ import javax.xml.stream.XMLStreamReader;
 
 import io.xlate.edi.schema.EDISchemaException;
 import io.xlate.edi.schema.EDIType;
+import io.xlate.edi.schema.SchemaFactory;
 
 public class SchemaReaderV4 extends SchemaReaderV3 {
 
-    public SchemaReaderV4(XMLStreamReader reader) {
-        super(StaEDISchemaFactory.XMLNS_V4, reader);
+    public SchemaReaderV4(XMLStreamReader reader, Map<String, Object> properties) {
+        super(StaEDISchemaFactory.XMLNS_V4, reader, properties);
     }
 
     @Override
@@ -24,9 +25,21 @@ public class SchemaReaderV4 extends SchemaReaderV3 {
     @Override
     protected void readInclude(XMLStreamReader reader, Map<String, EDIType> types) throws EDISchemaException {
         String location = parseAttribute(reader, "schemaLocation", String::valueOf);
+        URL context = null;
 
         try {
-            types.putAll(StaEDISchemaFactory.readSchemaTypes(new URL(location)));
+            if (properties.containsKey(SchemaFactory.SCHEMA_LOCATION_URL_CONTEXT)) {
+                Object ctx = properties.get(SchemaFactory.SCHEMA_LOCATION_URL_CONTEXT);
+
+                if (ctx instanceof URL) {
+                    context = (URL) ctx;
+                } else {
+                    context = new URL(String.valueOf(ctx));
+                }
+            }
+
+            URL schemaLocation = context != null ? new URL(context, location) : new URL(location);
+            types.putAll(StaEDISchemaFactory.readSchemaTypes(schemaLocation, super.properties));
             reader.nextTag(); // End of include
         } catch (Exception e) {
             throw schemaException("Exception reading included schema", reader, e);

--- a/src/main/java/io/xlate/edi/schema/SchemaFactory.java
+++ b/src/main/java/io/xlate/edi/schema/SchemaFactory.java
@@ -18,7 +18,18 @@ package io.xlate.edi.schema;
 import java.io.InputStream;
 import java.net.URL;
 
+@SuppressWarnings("java:S1214") // Allow constant string value to be used in this interface
 public interface SchemaFactory {
+
+    /**
+     * Property key for a URL (<code>java.lang.String</code> or
+     * <code>java.net.URL</code>) to be used with relative file URLs in
+     * <code>&lt;include schemaLocation="..."&gt;</code> element/attributes
+     * processed by a SchemaFactory. Besides a java.net.URL, any class with a
+     * toString method that returns a valid URL-formated String may be used as
+     * the value for this property.
+     */
+    public static final String SCHEMA_LOCATION_URL_CONTEXT = "io.xlate.edi.schema.SCHEMA_LOCATION_URL_CONTEXT";
 
     /**
      * Create a new instance of the factory. This static method creates a new
@@ -38,13 +49,16 @@ public interface SchemaFactory {
     public abstract Schema createSchema(InputStream stream) throws EDISchemaException;
 
     /**
-     * Retrieve the control schema for the provided standard and version. This method
-     * loads an internal, immutable schema provided by StAEDI.
+     * Retrieve the control schema for the provided standard and version. This
+     * method loads an internal, immutable schema provided by StAEDI.
      *
-     * @param standard the standard, e.g. X12 or EDIFACT
-     * @param version the version of the standard
+     * @param standard
+     *            the standard, e.g. X12 or EDIFACT
+     * @param version
+     *            the version of the standard
      * @return the control schema corresponding to the standard and version
-     * @throws EDISchemaException when the schema can not be loaded.
+     * @throws EDISchemaException
+     *             when the schema can not be loaded.
      *
      * @since 1.5
      */

--- a/src/test/java/io/xlate/edi/internal/schema/StaEDISchemaTest.java
+++ b/src/test/java/io/xlate/edi/internal/schema/StaEDISchemaTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Map;
 
 import javax.xml.stream.FactoryConfigurationError;
@@ -48,7 +49,7 @@ class StaEDISchemaTest {
         InputStream schemaStream = getClass().getResourceAsStream("/X12/v00200.xml");
         XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(schemaStream);
         reader.nextTag(); // Pass by <schema> element
-        Map<String, EDIType> types = new SchemaReaderV4(reader).readTypes();
+        Map<String, EDIType> types = new SchemaReaderV4(reader, Collections.emptyMap()).readTypes();
         schema.setTypes(types);
 
         assertEquals(EDIType.Type.INTERCHANGE, schema.getType(StaEDISchema.INTERCHANGE_ID).getType());
@@ -60,7 +61,7 @@ class StaEDISchemaTest {
         InputStream schemaStream = getClass().getResourceAsStream("/X12/v00402.xml");
         XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(schemaStream);
         reader.nextTag(); // Pass by <schema> element
-        Map<String, EDIType> types = new SchemaReaderV4(reader).readTypes();
+        Map<String, EDIType> types = new SchemaReaderV4(reader, Collections.emptyMap()).readTypes();
         schema.setTypes(types);
 
         assertEquals(EDIType.Type.INTERCHANGE, schema.getType(StaEDISchema.INTERCHANGE_ID).getType());
@@ -72,7 +73,7 @@ class StaEDISchemaTest {
         InputStream schemaStream = getClass().getResourceAsStream("/EDIFACT/CONTRL-v4r02.xml");
         XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(schemaStream);
         reader.nextTag(); // Pass by <schema> element
-        Map<String, EDIType> types = new SchemaReaderV3(reader).readTypes();
+        Map<String, EDIType> types = new SchemaReaderV3(reader, Collections.emptyMap()).readTypes();
         schema.setTypes(types);
 
         assertEquals(EDIType.Type.TRANSACTION, schema.getType(StaEDISchema.TRANSACTION_ID).getType());
@@ -87,7 +88,7 @@ class StaEDISchemaTest {
         InputStream schemaStream = getClass().getResourceAsStream("/x12/IG-999-standard-included.xml");
         XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(schemaStream);
         reader.nextTag(); // Pass by <schema> element
-        Map<String, EDIType> types = new SchemaReaderV4(reader).readTypes();
+        Map<String, EDIType> types = new SchemaReaderV4(reader, Collections.emptyMap()).readTypes();
         schema.setTypes(types);
 
         assertEquals(EDIType.Type.TRANSACTION, schema.getType(StaEDISchema.TRANSACTION_ID).getType());

--- a/src/test/resources/x12/IG-999-standard-included-relative.xml
+++ b/src/test/resources/x12/IG-999-standard-included-relative.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<schema xmlns="http://xlate.io/EDISchema/v4">
+  <include schemaLocation="file:./EDISchema999.xml" />
+
+  <implementation>
+    <sequence>
+      <segment type="AK1">
+        <sequence>
+          <element position="2" minOccurs="1">
+            <description>Element AK102</description>
+          </element>
+          <element position="1" minOccurs="1" />
+          <element position="3" minOccurs="1" />
+        </sequence>
+      </segment>
+
+      <loop code="AK2" type="L0001" title="Transaction Set Response Header">
+        <sequence>
+          <segment type="AK2">
+          <!-- Unchanged from standard -->
+          </segment>
+
+          <loop code="IK3" type="L0002" title="Error Identification">
+            <sequence>
+              <segment type="IK3">
+                <sequence>
+                  <element position="1" minOccurs="1" />
+                  <element position="2" minOccurs="1" />
+                  <element position="3" minOccurs="0" />
+                  <element position="4" minOccurs="1" />
+                </sequence>
+              </segment>
+              <segment type="CTX" discriminator="01.01" maxOccurs="9">
+                <sequence>
+                  <composite position="1">
+                    <sequence>
+                      <element position="1">
+                        <enumeration>
+                          <value>SITUATIONAL TRIGGER</value>
+                        </enumeration>
+                      </element>
+                    </sequence>
+                  </composite>
+                  <element position="2" minOccurs="1" />
+                  <element position="3" minOccurs="1" />
+                  <element position="4" />
+                  <composite position="5" />
+                  <composite position="6">
+                    <sequence>
+                      <element position="1" />
+                    </sequence>
+                  </composite>
+                </sequence>
+              </segment>
+              <segment type="CTX" maxOccurs="1">
+                <sequence>
+                  <composite position="1">
+                    <sequence>
+                      <element position="1" minOccurs="1" />
+                      <element position="2" minOccurs="1" />
+                    </sequence>
+                  </composite>
+                    <!-- Remaining elements are not used. -->
+                </sequence>
+              </segment>
+              <loop code="IK4" type="L0003" title="Implementation Data Element Note">
+                <sequence>
+                  <segment type="IK4">
+                      <!-- Unchanged from standard -->
+                  </segment>
+                  <segment type="CTX" maxOccurs="10">
+                    <sequence>
+                      <composite position="1">
+                        <sequence>
+                          <element position="1">
+                            <enumeration>
+                              <value>SITUATIONAL TRIGGER</value>
+                            </enumeration>
+                          </element>
+                        </sequence>
+                      </composite>
+                      <element position="2" minOccurs="1" />
+                      <element position="3" minOccurs="1" />
+                      <element position="4" />
+                      <composite position="5" minOccurs="1" />
+                      <composite position="6">
+                        <sequence>
+                          <element position="1" />
+                        </sequence>
+                      </composite>
+                    </sequence>
+                  </segment>
+                </sequence>
+              </loop>
+            </sequence>
+          </loop>
+          <segment type="IK5">
+              <!-- Unchanged from standard -->
+          </segment>
+        </sequence>
+      </loop>
+      <segment type="AK9">
+          <!-- Unchanged from standard -->
+      </segment>
+    </sequence>
+  </implementation>
+</schema>


### PR DESCRIPTION
Fixes #40 

Allows for the relative URLs (besides relative to working directory) to be used in the `schemaLocation` attribute of the `include` element.