### PR TITLE
Add interface to report output errors; align name for input reporter

### DIFF
--- a/src/main/java/io/xlate/edi/internal/stream/StaEDIInputFactory.java
+++ b/src/main/java/io/xlate/edi/internal/stream/StaEDIInputFactory.java
@@ -24,15 +24,15 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import io.xlate.edi.schema.Schema;
+import io.xlate.edi.stream.EDIInputErrorReporter;
 import io.xlate.edi.stream.EDIInputFactory;
-import io.xlate.edi.stream.EDIReporter;
 import io.xlate.edi.stream.EDIStreamException;
 import io.xlate.edi.stream.EDIStreamFilter;
 import io.xlate.edi.stream.EDIStreamReader;
 
 public class StaEDIInputFactory extends EDIInputFactory {
 
-    private EDIReporter reporter;
+    private EDIInputErrorReporter reporter;
 
     public StaEDIInputFactory() {
         supportedProperties.add(EDI_VALIDATE_CONTROL_STRUCTURE);
@@ -52,7 +52,7 @@ public class StaEDIInputFactory extends EDIInputFactory {
 
     @Override
     public EDIStreamReader createEDIStreamReader(InputStream stream, Schema schema) {
-        return new StaEDIStreamReader(stream, StandardCharsets.UTF_8, schema, properties, getEDIReporter());
+        return new StaEDIStreamReader(stream, StandardCharsets.UTF_8, schema, properties, getErrorReporter());
     }
 
     @SuppressWarnings("resource")
@@ -61,7 +61,7 @@ public class StaEDIInputFactory extends EDIInputFactory {
         Objects.requireNonNull(stream);
 
         if (Charset.isSupported(encoding)) {
-            return new StaEDIStreamReader(stream, Charset.forName(encoding), schema, properties, getEDIReporter());
+            return new StaEDIStreamReader(stream, Charset.forName(encoding), schema, properties, getErrorReporter());
         }
 
         throw new EDIStreamException("Unsupported encoding: " + encoding);
@@ -78,12 +78,32 @@ public class StaEDIInputFactory extends EDIInputFactory {
     }
 
     @Override
-    public EDIReporter getEDIReporter() {
+    public EDIInputErrorReporter getErrorReporter() {
         return reporter;
     }
 
     @Override
-    public void setEDIReporter(EDIReporter reporter) {
+    public void setErrorReporter(EDIInputErrorReporter reporter) {
         this.reporter = reporter;
+    }
+
+    @Override
+    @SuppressWarnings({ "java:S1123", "java:S1133" })
+    @Deprecated /*(forRemoval = true, since = "1.9")*/
+    public io.xlate.edi.stream.EDIReporter getEDIReporter() {
+        EDIInputErrorReporter errorReporter = getErrorReporter();
+
+        if (errorReporter instanceof io.xlate.edi.stream.EDIReporter) {
+            return (io.xlate.edi.stream.EDIReporter) errorReporter;
+        }
+
+        throw new ClassCastException("Can not cast reporter to EDIReporter; did you mean to call getErrorReporter() ?");
+    }
+
+    @Override
+    @SuppressWarnings({ "java:S1123", "java:S1133" })
+    @Deprecated /*(forRemoval = true, since = "1.9")*/
+    public void setEDIReporter(io.xlate.edi.stream.EDIReporter reporter) {
+        setErrorReporter(reporter);
     }
 }

--- a/src/main/java/io/xlate/edi/internal/stream/StaEDIOutputFactory.java
+++ b/src/main/java/io/xlate/edi/internal/stream/StaEDIOutputFactory.java
@@ -21,12 +21,15 @@ import java.nio.charset.StandardCharsets;
 
 import javax.xml.stream.XMLStreamWriter;
 
+import io.xlate.edi.stream.EDIOutputErrorReporter;
 import io.xlate.edi.stream.EDIOutputFactory;
 import io.xlate.edi.stream.EDIStreamConstants;
 import io.xlate.edi.stream.EDIStreamException;
 import io.xlate.edi.stream.EDIStreamWriter;
 
 public class StaEDIOutputFactory extends EDIOutputFactory {
+
+    private EDIOutputErrorReporter reporter;
 
     public StaEDIOutputFactory() {
         supportedProperties.add(EDIStreamConstants.Delimiters.SEGMENT);
@@ -43,13 +46,13 @@ public class StaEDIOutputFactory extends EDIOutputFactory {
 
     @Override
     public EDIStreamWriter createEDIStreamWriter(OutputStream stream) {
-        return new StaEDIStreamWriter(stream, StandardCharsets.UTF_8, properties);
+        return new StaEDIStreamWriter(stream, StandardCharsets.UTF_8, properties, reporter);
     }
 
     @Override
     public EDIStreamWriter createEDIStreamWriter(OutputStream stream, String encoding) throws EDIStreamException {
         if (Charset.isSupported(encoding)) {
-            return new StaEDIStreamWriter(stream, Charset.forName(encoding), properties);
+            return new StaEDIStreamWriter(stream, Charset.forName(encoding), properties, reporter);
         }
         throw new EDIStreamException("Unsupported encoding: " + encoding);
     }
@@ -57,5 +60,15 @@ public class StaEDIOutputFactory extends EDIOutputFactory {
     @Override
     public XMLStreamWriter createXMLStreamWriter(EDIStreamWriter writer) {
         return new StaEDIXMLStreamWriter(writer);
+    }
+
+    @Override
+    public EDIOutputErrorReporter getErrorReporter() {
+        return this.reporter;
+    }
+
+    @Override
+    public void setErrorReporter(EDIOutputErrorReporter reporter) {
+        this.reporter = reporter;
     }
 }

--- a/src/main/java/io/xlate/edi/internal/stream/StaEDIStreamReader.java
+++ b/src/main/java/io/xlate/edi/internal/stream/StaEDIStreamReader.java
@@ -34,8 +34,8 @@ import io.xlate.edi.internal.stream.tokenization.Lexer;
 import io.xlate.edi.internal.stream.tokenization.ProxyEventHandler;
 import io.xlate.edi.schema.EDISchemaException;
 import io.xlate.edi.schema.Schema;
+import io.xlate.edi.stream.EDIInputErrorReporter;
 import io.xlate.edi.stream.EDIInputFactory;
-import io.xlate.edi.stream.EDIReporter;
 import io.xlate.edi.stream.EDIStreamEvent;
 import io.xlate.edi.stream.EDIStreamException;
 import io.xlate.edi.stream.EDIStreamReader;
@@ -48,7 +48,7 @@ public class StaEDIStreamReader implements EDIStreamReader {
 
     private Schema controlSchema;
     private final Map<String, Object> properties;
-    private final EDIReporter reporter;
+    private final EDIInputErrorReporter reporter;
     private final StaEDIStreamLocation location = new StaEDIStreamLocation();
     private final ProxyEventHandler proxy;
     private final Lexer lexer;
@@ -61,7 +61,7 @@ public class StaEDIStreamReader implements EDIStreamReader {
             Charset charset,
             Schema schema,
             Map<String, Object> properties,
-            EDIReporter reporter) {
+            EDIInputErrorReporter reporter) {
 
         this.controlSchema = schema;
         this.properties = new HashMap<>(properties);

--- a/src/main/java/io/xlate/edi/stream/EDIInputErrorReporter.java
+++ b/src/main/java/io/xlate/edi/stream/EDIInputErrorReporter.java
@@ -1,0 +1,23 @@
+package io.xlate.edi.stream;
+
+/**
+ * This interface is used to report non-fatal errors detected in an EDI input.
+ *
+ * @since 1.9
+ */
+public interface EDIInputErrorReporter {
+    /**
+     * Report the desired message in an application specific format. Only
+     * warnings and non-fatal errors should be reported through this interface.
+     *
+     * Fatal errors will be thrown as EDIStreamException.
+     *
+     * @param errorType
+     *            the type of error detected
+     * @param reader
+     *            the EDIStreamReader that encountered the error
+     * @throws EDIStreamException
+     *             when errors occur calling the reader
+     */
+    void report(EDIStreamValidationError errorType, EDIStreamReader reader) throws EDIStreamException;
+}

--- a/src/main/java/io/xlate/edi/stream/EDIInputFactory.java
+++ b/src/main/java/io/xlate/edi/stream/EDIInputFactory.java
@@ -215,8 +215,14 @@ public abstract class EDIInputFactory extends PropertySupport {
      * @return the reporter that will be set on any EDIStreamReader created by
      *         this factory instance
      *
+     * @throws ClassCastException
+     *             when reporter is not an instance of EDIReporter
+     *
      * @since 1.4
+     * @deprecated use {@link #getErrorReporter()} instead
      */
+    @SuppressWarnings({ "java:S1123", "java:S1133" })
+    @Deprecated /*(forRemoval = true, since = "1.9")*/
     public abstract EDIReporter getEDIReporter();
 
     /**
@@ -231,6 +237,35 @@ public abstract class EDIInputFactory extends PropertySupport {
      *            the resolver to use to report non fatal errors
      *
      * @since 1.4
+     * @deprecated use {@link #setErrorReporter(EDIInputErrorReporter)} instead
      */
+    @SuppressWarnings({ "java:S1123", "java:S1133" })
+    @Deprecated /*(forRemoval = true, since = "1.9")*/
     public abstract void setEDIReporter(EDIReporter reporter);
+
+    /**
+     * Retrieves the reporter that will be set on any EDIStreamReader created by
+     * this factory instance.
+     *
+     * @return the reporter that will be set on any EDIStreamReader created by
+     *         this factory instance
+     *
+     * @since 1.9
+     */
+    public abstract EDIInputErrorReporter getErrorReporter();
+
+    /**
+     * The reporter that will be set on any EDIStreamReader created by this
+     * factory instance.
+     *
+     * NOTE: When using an EDIReporter, errors found in the data stream that are
+     * reported to the reporter will not appear in the stream of events returned
+     * by the EDIStreamReader.
+     *
+     * @param reporter
+     *            the resolver to use to report non fatal errors
+     *
+     * @since 1.9
+     */
+    public abstract void setErrorReporter(EDIInputErrorReporter reporter);
 }

--- a/src/main/java/io/xlate/edi/stream/EDIOutputErrorReporter.java
+++ b/src/main/java/io/xlate/edi/stream/EDIOutputErrorReporter.java
@@ -22,7 +22,7 @@ public interface EDIOutputErrorReporter {
      * @param data
      *            the invalid data, may be null (e.g. for missing required
      *            element errors)
-     * @param referenceCode
+     * @param code
      *            the reference code for the invalid data, if available from the
      *            current schema used for validation
      */

--- a/src/main/java/io/xlate/edi/stream/EDIOutputErrorReporter.java
+++ b/src/main/java/io/xlate/edi/stream/EDIOutputErrorReporter.java
@@ -1,0 +1,30 @@
+package io.xlate.edi.stream;
+
+/**
+ * This interface is used to report non-fatal errors detected in an EDI input.
+ *
+ * @since 1.9
+ */
+public interface EDIOutputErrorReporter {
+    /**
+     * Report the desired message in an application specific format. Only
+     * warnings and non-fatal errors should be reported through this interface.
+     *
+     * Fatal errors will be thrown as {@link EDIStreamException}s.
+     *
+     * @param errorType
+     *            the type of error detected
+     * @param writer
+     *            the EDIStreamWriter that encountered the error
+     * @param location
+     *            the location of the error, may be different than the location
+     *            returned by the writer (e.g. for derived element positions)
+     * @param data
+     *            the invalid data, may be null (e.g. for missing required
+     *            element errors)
+     * @param referenceCode
+     *            the reference code for the invalid data, if available from the
+     *            current schema used for validation
+     */
+    void report(EDIStreamValidationError errorType, EDIStreamWriter writer, Location location, CharSequence data, CharSequence code);
+}

--- a/src/main/java/io/xlate/edi/stream/EDIOutputFactory.java
+++ b/src/main/java/io/xlate/edi/stream/EDIOutputFactory.java
@@ -22,19 +22,23 @@ import javax.xml.stream.XMLStreamWriter;
 public abstract class EDIOutputFactory extends PropertySupport {
 
     /**
-     * <p>When set to true, the EDI output will have a platform specific line
+     * <p>
+     * When set to true, the EDI output will have a platform specific line
      * separator written after each segment terminator.
      *
-     * <p>Default value is false.
+     * <p>
+     * Default value is false.
      */
     public static final String PRETTY_PRINT = "io.xlate.edi.stream.PRETTY_PRINT";
 
     /**
-     * <p>When set to true, empty trailing elements in a segment and empty trailing
+     * <p>
+     * When set to true, empty trailing elements in a segment and empty trailing
      * components in a composite element will be truncated. I.e, they will not
      * be written to the output.
      *
-     * <p>Default value is false.
+     * <p>
+     * Default value is false.
      */
     public static final String TRUNCATE_EMPTY_ELEMENTS = "io.xlate.edi.stream.TRUNCATE_EMPTY_ELEMENTS";
 
@@ -90,4 +94,30 @@ public abstract class EDIOutputFactory extends PropertySupport {
      * @return a new {@link XMLStreamWriter}
      */
     public abstract XMLStreamWriter createXMLStreamWriter(EDIStreamWriter writer);
+
+    /**
+     * Retrieves the reporter that will be set on any EDIStreamWriter created by
+     * this factory instance.
+     *
+     * @return the reporter that will be set on any EDIStreamWriter created by
+     *         this factory instance
+     *
+     * @since 1.9
+     */
+    public abstract EDIOutputErrorReporter getErrorReporter();
+
+    /**
+     * The reporter that will be set on any EDIStreamWriter created by this
+     * factory instance.
+     *
+     * NOTE: When using an EDIOutputErrorReporter, errors found in the data
+     * stream that are reported to the reporter will not be throw as instances
+     * of {@link EDIValidationException}.
+     *
+     * @param reporter
+     *            the resolver to use to report non fatal errors
+     *
+     * @since 1.9
+     */
+    public abstract void setErrorReporter(EDIOutputErrorReporter reporter);
 }

--- a/src/main/java/io/xlate/edi/stream/EDIReporter.java
+++ b/src/main/java/io/xlate/edi/stream/EDIReporter.java
@@ -4,20 +4,10 @@ package io.xlate.edi.stream;
  * This interface is used to report non-fatal errors detected in an EDI input.
  *
  * @since 1.4
+ * @deprecated implement EDIInputErrorReporter instead. This interface will be
+ *             removed in a future version of StAEDI.
  */
-public interface EDIReporter {
-    /**
-     * Report the desired message in an application specific format. Only
-     * warnings and non-fatal errors should be reported through this interface.
-     *
-     * Fatal errors will be thrown as EDIStreamException.
-     *
-     * @param errorType
-     *            the type of error detected
-     * @param reader
-     *            the EDIStreamReader that encountered the error
-     * @throws EDIStreamException
-     *             when errors occur calling the reader
-     */
-    void report(EDIStreamValidationError errorType, EDIStreamReader reader) throws EDIStreamException;
+@SuppressWarnings({ "java:S1123", "java:S1133" })
+@Deprecated/*(forRemoval = true, since = "1.9")*/
+public interface EDIReporter extends EDIInputErrorReporter {
 }

--- a/src/test/java/io/xlate/edi/internal/stream/StaEDIInputFactoryTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/StaEDIInputFactoryTest.java
@@ -18,16 +18,19 @@ package io.xlate.edi.internal.stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import io.xlate.edi.schema.EDISchemaException;
 import io.xlate.edi.schema.Schema;
 import io.xlate.edi.schema.SchemaFactory;
+import io.xlate.edi.stream.EDIInputErrorReporter;
 import io.xlate.edi.stream.EDIInputFactory;
 import io.xlate.edi.stream.EDIStreamException;
 import io.xlate.edi.stream.EDIStreamReader;
@@ -113,5 +116,25 @@ class StaEDIInputFactoryTest {
     void testSetPropertyUnsupported() {
         EDIInputFactory factory = EDIInputFactory.newFactory();
         assertThrows(IllegalArgumentException.class, () -> factory.setProperty("FOO", null));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void testDeprecatedReporterMethodUsesDeprecatedType() {
+        io.xlate.edi.stream.EDIReporter deprecatedReporter = Mockito.mock(io.xlate.edi.stream.EDIReporter.class);
+        EDIInputFactory factory = EDIInputFactory.newFactory();
+        factory.setEDIReporter(deprecatedReporter);
+        assertSame(deprecatedReporter, factory.getErrorReporter());
+        assertSame(deprecatedReporter, factory.getEDIReporter());
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void testDeprecatedReporterMethodThrowsException() {
+        EDIInputErrorReporter reporter = Mockito.mock(EDIInputErrorReporter.class);
+        EDIInputFactory factory = EDIInputFactory.newFactory();
+        factory.setErrorReporter(reporter);
+        assertSame(reporter, factory.getErrorReporter());
+        assertThrows(ClassCastException.class, () -> factory.getEDIReporter());
     }
 }

--- a/src/test/java/io/xlate/edi/internal/stream/StaEDIXMLStreamReaderTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/StaEDIXMLStreamReaderTest.java
@@ -792,7 +792,7 @@ class StaEDIXMLStreamReaderTest {
     void testEDIReporterSet() throws Exception {
         EDIInputFactory ediFactory = EDIInputFactory.newFactory();
         Map<String, Set<EDIStreamValidationError>> errors = new LinkedHashMap<>();
-        ediFactory.setEDIReporter((errorEvent, reader) -> {
+        ediFactory.setErrorReporter((errorEvent, reader) -> {
             Location location = reader.getLocation();
             String key;
 


### PR DESCRIPTION
Fixes #52 

Also deprecate `EDIReporter` used for input validation error reporting, use `EDIInputErrorReporter` instead