### PR TITLE
Update event array element types upon implementation segment selection

### DIFF
--- a/src/main/java/io/xlate/edi/internal/stream/StaEDIStreamReader.java
+++ b/src/main/java/io/xlate/edi/internal/stream/StaEDIStreamReader.java
@@ -333,6 +333,7 @@ public class StaEDIStreamReader implements EDIStreamReader {
         case END_SEGMENT:
         case ELEMENT_DATA:
         case ELEMENT_DATA_ERROR:
+        case ELEMENT_OCCURRENCE_ERROR:
         case SEGMENT_ERROR:
             break;
         default:

--- a/src/test/java/io/xlate/edi/internal/schema/implementation/SegmentImplTest.java
+++ b/src/test/java/io/xlate/edi/internal/schema/implementation/SegmentImplTest.java
@@ -29,7 +29,7 @@ class SegmentImplTest {
                 + "NM1*41*2*SAMPLE INC*****46*496103~"
                 + "PER*IC*EDI DEPT*EM*FEEDBACK@example.com*TE*3305551212~"
                 + "NM1*40*2*PPO BLUE*****46*54771~"
-                + "HL*1**20~"
+                + "HL*1**20*1~"
                 + "SE*6*0001~"
                 + "GE*1*1~"
                 + "IEA*1*000000001~").getBytes());

--- a/src/test/resources/x12/005010/837.xml
+++ b/src/test/resources/x12/005010/837.xml
@@ -555,10 +555,10 @@
   <elementType name="HI1207" base="string" maxLength="30"/>
   <elementType name="HI1208" base="string" maxLength="30"/>
   <elementType name="HI1209" base="string"/>
-  <elementType name="HL01" base="string" maxLength="12"/>
-  <elementType name="HL02" base="string" maxLength="12"/>
-  <elementType name="HL03" base="string" maxLength="2"/>
-  <elementType name="HL04" base="string"/>
+  <elementType name="HL01" base="string" maxLength="12" title="Hierarchical ID Number"/>
+  <elementType name="HL02" base="string" maxLength="12" title="Hierarchical Parent ID Number"/>
+  <elementType name="HL03" base="string" maxLength="2" title="Hierarchical Level Code"/>
+  <elementType name="HL04" base="string" title="Hierarchical Child Code"/>
   <elementType name="HSD01" base="string" minLength="2" maxLength="2"/>
   <elementType name="HSD02" base="decimal" maxLength="15"/>
   <elementType name="HSD03" base="string" minLength="2" maxLength="2"/>
@@ -694,7 +694,7 @@
   <elementType name="N405" base="string" maxLength="2"/>
   <elementType name="N406" base="string" maxLength="30"/>
   <elementType name="N407" base="string" maxLength="3"/>
-  <elementType name="NM101" base="string" minLength="2" maxLength="3"/>
+  <elementType name="NM101" base="string" minLength="2" maxLength="3" title="Entity Identifier Code"/>
   <elementType name="NM102" base="string"/>
   <elementType name="NM103" base="string" maxLength="60" title="Name Last or Organization Name"/>
   <elementType name="NM104" base="string" maxLength="35"/>

--- a/src/test/resources/x12/005010X222/837_loop1000_only.xml
+++ b/src/test/resources/x12/005010X222/837_loop1000_only.xml
@@ -11,7 +11,7 @@
         <sequence>
           <segment type="NM1" title="Submitter Name">
             <sequence>
-              <element position="1">
+              <element position="1" title="Entity Identifier Code (Submitter)">
                 <enumeration>
                   <value>41</value>
                 </enumeration>
@@ -32,7 +32,7 @@
         <sequence>
           <segment type="NM1" title="Receiver Name">
             <sequence>
-              <element position="1">
+              <element position="1" title="Entity Identifier Code (Receiver)">
                 <enumeration>
                   <value>40</value>
                 </enumeration>
@@ -46,9 +46,23 @@
         </sequence>
       </loop>
 
-      <loop code="2000A" type="L0002">
+      <loop code="2000A" type="L0002" discriminator="3" title="Billing Provider Level (2000A)" >
         <sequence>
-          <segment type="HL" />
+          <segment type="HL" title="Billing Provider Level (HL)">
+            <sequence>
+              <element position="1" title="Hierarchical ID Number (20)" />
+              <element position="3" title="Hierarchical Level Code (20)">
+                <enumeration>
+                  <value title="Information Source">20</value>
+                </enumeration>
+              </element>
+              <element position="4" minOccurs="1" title="Hierarchical Child Code (20)">
+                <enumeration>
+                  <value>1</value>
+                </enumeration>
+              </element>
+            </sequence>
+          </segment>
         </sequence>
       </loop>
     </sequence>


### PR DESCRIPTION
Fixes #87 

- Clean up composite/element retrieval from `Validator`
- Re-factor handling of derived composites to allow proper selection of element types
- Allow `getText` call on `EDIStreamReader` for `ELEMENT_OCCURRENCE_ERROR` event