### PR TITLE
Add option to format (pad) output elements to minimum required lengths

### DIFF
--- a/src/main/java/io/xlate/edi/internal/stream/StaEDIOutputFactory.java
+++ b/src/main/java/io/xlate/edi/internal/stream/StaEDIOutputFactory.java
@@ -40,6 +40,7 @@ public class StaEDIOutputFactory extends EDIOutputFactory {
         supportedProperties.add(EDIStreamConstants.Delimiters.RELEASE);
         supportedProperties.add(PRETTY_PRINT);
         supportedProperties.add(TRUNCATE_EMPTY_ELEMENTS);
+        supportedProperties.add(FORMAT_ELEMENTS);
 
         properties.put(PRETTY_PRINT, Boolean.FALSE);
     }

--- a/src/main/java/io/xlate/edi/internal/stream/tokenization/EDIException.java
+++ b/src/main/java/io/xlate/edi/internal/stream/tokenization/EDIException.java
@@ -62,8 +62,4 @@ public class EDIException extends EDIStreamException {
         super(exceptionMessages.get(id) + "; " + message);
     }
 
-    public EDIException(Throwable cause) {
-        super(cause);
-    }
-
 }

--- a/src/main/java/io/xlate/edi/internal/stream/tokenization/ProxyEventHandler.java
+++ b/src/main/java/io/xlate/edi/internal/stream/tokenization/ProxyEventHandler.java
@@ -68,7 +68,7 @@ public class ProxyEventHandler implements EventHandler {
         }
 
         this.controlSchema = controlSchema;
-        controlValidator = controlSchema != null ? new Validator(controlSchema, validateCodeValues, null) : null;
+        controlValidator = validatorInstance(controlSchema, null, validateCodeValues);
     }
 
     public boolean isTransactionSchemaAllowed() {
@@ -82,8 +82,12 @@ public class ProxyEventHandler implements EventHandler {
     public void setTransactionSchema(Schema transactionSchema) {
         if (!Objects.equals(this.transactionSchema, transactionSchema)) {
             this.transactionSchema = transactionSchema;
-            transactionValidator = transactionSchema != null ? new Validator(transactionSchema, true, controlSchema) : null;
+            transactionValidator = validatorInstance(transactionSchema, controlSchema, true);
         }
+    }
+
+    Validator validatorInstance(Schema schema, Schema containerSchema, boolean validateCodeValues) {
+        return schema != null ? new Validator(schema, containerSchema, validateCodeValues) : null;
     }
 
     public void resetEvents() {
@@ -246,7 +250,7 @@ public class ProxyEventHandler implements EventHandler {
 
         if (validator != null) {
             validator.validateSyntax(dialect, this, this, location, false);
-            validator.validateVersionConstraints(dialect, this);
+            validator.validateVersionConstraints(dialect, this, null);
             typeReference = validator.getSegmentReference();
         }
 
@@ -307,7 +311,7 @@ public class ProxyEventHandler implements EventHandler {
         boolean valid;
 
         if (validator != null) {
-            valid = validator.validateElement(dialect, location, elementHolder);
+            valid = validator.validateElement(dialect, location, elementHolder, null);
             derivedComposite = !compositeFromStream && validator.isComposite();
             typeReference = validator.getElementReference();
             enqueueElementOccurrenceErrors(validator, valid);

--- a/src/main/java/io/xlate/edi/internal/stream/validation/AlphaNumericValidator.java
+++ b/src/main/java/io/xlate/edi/internal/stream/validation/AlphaNumericValidator.java
@@ -15,17 +15,13 @@
  ******************************************************************************/
 package io.xlate.edi.internal.stream.validation;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
 import io.xlate.edi.internal.stream.tokenization.CharacterSet;
 import io.xlate.edi.internal.stream.tokenization.Dialect;
-import io.xlate.edi.internal.stream.tokenization.EDIException;
 import io.xlate.edi.schema.EDISimpleType;
-import io.xlate.edi.stream.EDIStreamEvent;
 import io.xlate.edi.stream.EDIStreamValidationError;
-import io.xlate.edi.stream.EDIValidationException;
 
 class AlphaNumericValidator extends ElementValidator {
 
@@ -64,33 +60,15 @@ class AlphaNumericValidator extends ElementValidator {
     }
 
     @Override
-    void format(Dialect dialect, EDISimpleType element, CharSequence value, Appendable result) throws EDIException {
+    void format(Dialect dialect, EDISimpleType element, CharSequence value, StringBuilder result) {
         int length = value.length();
-        assertMaxLength(element, value);
 
-        Set<String> valueSet = element.getValueSet();
-
-        if (!valueSet.isEmpty() && !valueSet.contains(value.toString())) {
-            throw new EDIValidationException(EDIStreamEvent.ELEMENT_DATA, EDIStreamValidationError.INVALID_CODE_VALUE, null, value);
+        for (int i = 0; i < length; i++) {
+            result.append(value.charAt(i));
         }
 
-        try {
-            for (int i = 0; i < length; i++) {
-                char character = value.charAt(i);
-
-                if (!CharacterSet.isValid(character)) {
-                    throw new EDIException(EDIException.INVALID_CHARACTER,
-                                           "Invalid character 0x" + String.format("%04X", (int) character));
-                }
-
-                result.append(character);
-            }
-
-            for (long i = length, min = element.getMinLength(); i < min; i++) {
-                result.append(' ');
-            }
-        } catch (IOException e) {
-            throw new EDIException(e);
+        for (long i = length, min = element.getMinLength(); i < min; i++) {
+            result.append(' ');
         }
     }
 }

--- a/src/main/java/io/xlate/edi/internal/stream/validation/DateValidator.java
+++ b/src/main/java/io/xlate/edi/internal/stream/validation/DateValidator.java
@@ -15,16 +15,12 @@
  ******************************************************************************/
 package io.xlate.edi.internal.stream.validation;
 
-import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 
 import io.xlate.edi.internal.stream.tokenization.Dialect;
-import io.xlate.edi.internal.stream.tokenization.EDIException;
 import io.xlate.edi.schema.EDISimpleType;
-import io.xlate.edi.stream.EDIStreamEvent;
 import io.xlate.edi.stream.EDIStreamValidationError;
-import io.xlate.edi.stream.EDIValidationException;
 
 class DateValidator extends ElementValidator {
 
@@ -51,19 +47,8 @@ class DateValidator extends ElementValidator {
     }
 
     @Override
-    void format(Dialect dialect, EDISimpleType element, CharSequence value, Appendable result) throws EDIException {
-        assertMinLength(element, value);
-        assertMaxLength(element, value);
-
-        if (!validValue(value)) {
-            throw new EDIValidationException(EDIStreamEvent.ELEMENT_DATA, EDIStreamValidationError.INVALID_DATE, null, value);
-        }
-
-        try {
-            result.append(value);
-        } catch (IOException e) {
-            throw new EDIException(e);
-        }
+    void format(Dialect dialect, EDISimpleType element, CharSequence value, StringBuilder result) {
+        result.append(value);
     }
 
     static boolean validValue(CharSequence value) {

--- a/src/main/java/io/xlate/edi/internal/stream/validation/ElementValidator.java
+++ b/src/main/java/io/xlate/edi/internal/stream/validation/ElementValidator.java
@@ -18,7 +18,6 @@ package io.xlate.edi.internal.stream.validation;
 import java.util.List;
 
 import io.xlate.edi.internal.stream.tokenization.Dialect;
-import io.xlate.edi.internal.stream.tokenization.EDIException;
 import io.xlate.edi.schema.EDISimpleType;
 import io.xlate.edi.stream.EDIStreamEvent;
 import io.xlate.edi.stream.EDIStreamValidationError;
@@ -97,6 +96,5 @@ abstract class ElementValidator {
     abstract void format(Dialect dialect,
                          EDISimpleType element,
                          CharSequence value,
-                         Appendable result)
-            throws EDIException;
+                         StringBuilder result);
 }

--- a/src/main/java/io/xlate/edi/internal/stream/validation/ElementValidator.java
+++ b/src/main/java/io/xlate/edi/internal/stream/validation/ElementValidator.java
@@ -19,9 +19,7 @@ import java.util.List;
 
 import io.xlate.edi.internal.stream.tokenization.Dialect;
 import io.xlate.edi.schema.EDISimpleType;
-import io.xlate.edi.stream.EDIStreamEvent;
 import io.xlate.edi.stream.EDIStreamValidationError;
-import io.xlate.edi.stream.EDIValidationException;
 
 abstract class ElementValidator {
 
@@ -70,22 +68,6 @@ abstract class ElementValidator {
         }
 
         return true;
-    }
-
-    protected static void assertMinLength(EDISimpleType element, CharSequence value) {
-        if (value.length() < element.getMinLength()) {
-            throw new EDIValidationException(EDIStreamEvent.ELEMENT_DATA, EDIStreamValidationError.DATA_ELEMENT_TOO_SHORT, null, value);
-        }
-    }
-
-    protected static void assertMaxLength(EDISimpleType element, int length, CharSequence value) {
-        if (length > element.getMaxLength()) {
-            throw new EDIValidationException(EDIStreamEvent.ELEMENT_DATA, EDIStreamValidationError.DATA_ELEMENT_TOO_LONG, null, value);
-        }
-    }
-
-    protected static void assertMaxLength(EDISimpleType element, CharSequence value) {
-        assertMaxLength(element, value.length(), value);
     }
 
     abstract void validate(Dialect dialect,

--- a/src/main/java/io/xlate/edi/internal/stream/validation/NumericValidator.java
+++ b/src/main/java/io/xlate/edi/internal/stream/validation/NumericValidator.java
@@ -15,15 +15,11 @@
  ******************************************************************************/
 package io.xlate.edi.internal.stream.validation;
 
-import java.io.IOException;
 import java.util.List;
 
 import io.xlate.edi.internal.stream.tokenization.Dialect;
-import io.xlate.edi.internal.stream.tokenization.EDIException;
 import io.xlate.edi.schema.EDISimpleType;
-import io.xlate.edi.stream.EDIStreamEvent;
 import io.xlate.edi.stream.EDIStreamValidationError;
-import io.xlate.edi.stream.EDIValidationException;
 
 class NumericValidator extends ElementValidator {
 
@@ -47,23 +43,14 @@ class NumericValidator extends ElementValidator {
     }
 
     @Override
-    void format(Dialect dialect, EDISimpleType element, CharSequence value, Appendable result) throws EDIException {
+    void format(Dialect dialect, EDISimpleType element, CharSequence value, StringBuilder result) {
         int length = validate(dialect, value);
-        assertMaxLength(element, Math.abs(length), value);
 
-        if (length < 0) {
-            throw new EDIValidationException(EDIStreamEvent.ELEMENT_DATA, EDIStreamValidationError.INVALID_CHARACTER_DATA, null, value);
+        for (long i = length, min = element.getMinLength(); i < min; i++) {
+            result.append('0');
         }
 
-        try {
-            for (long i = length, min = element.getMinLength(); i < min; i++) {
-                result.append('0');
-            }
-
-            result.append(value);
-        } catch (IOException e) {
-            throw new EDIException(e);
-        }
+        result.append(value);
     }
 
     /**

--- a/src/main/java/io/xlate/edi/internal/stream/validation/TimeValidator.java
+++ b/src/main/java/io/xlate/edi/internal/stream/validation/TimeValidator.java
@@ -15,15 +15,11 @@
  ******************************************************************************/
 package io.xlate.edi.internal.stream.validation;
 
-import java.io.IOException;
 import java.util.List;
 
 import io.xlate.edi.internal.stream.tokenization.Dialect;
-import io.xlate.edi.internal.stream.tokenization.EDIException;
 import io.xlate.edi.schema.EDISimpleType;
-import io.xlate.edi.stream.EDIStreamEvent;
 import io.xlate.edi.stream.EDIStreamValidationError;
-import io.xlate.edi.stream.EDIValidationException;
 
 class TimeValidator extends ElementValidator {
 
@@ -49,22 +45,13 @@ class TimeValidator extends ElementValidator {
     }
 
     @Override
-    void format(Dialect dialect, EDISimpleType element, CharSequence value, Appendable result) throws EDIException {
+    void format(Dialect dialect, EDISimpleType element, CharSequence value, StringBuilder result) {
         int length = value.length();
-        assertMaxLength(element, value);
 
-        if (!validValue(value)) {
-            throw new EDIValidationException(EDIStreamEvent.ELEMENT_DATA, EDIStreamValidationError.INVALID_TIME, null, value);
-        }
+        result.append(value);
 
-        try {
-            result.append(value);
-
-            for (long i = length, min = element.getMinLength(); i < min; i++) {
-                result.append('0');
-            }
-        } catch (IOException e) {
-            throw new EDIException(e);
+        for (long i = length, min = element.getMinLength(); i < min; i++) {
+            result.append('0');
         }
     }
 

--- a/src/main/java/io/xlate/edi/internal/stream/validation/UsageNode.java
+++ b/src/main/java/io/xlate/edi/internal/stream/validation/UsageNode.java
@@ -141,11 +141,11 @@ class UsageNode {
     }
 
     void validate(Dialect dialect, CharSequence value, List<EDIStreamValidationError> errors) {
-        if (validator == null) {
-            throw new UnsupportedOperationException("simple type only");
-        }
-
         validator.validate(dialect, getSimpleType(), value, errors);
+    }
+
+    void format(Dialect dialect, CharSequence value, StringBuilder result) {
+        validator.format(dialect, getSimpleType(), value, result);
     }
 
     List<EDISyntaxRule> getSyntaxRules() {

--- a/src/main/java/io/xlate/edi/stream/EDIOutputFactory.java
+++ b/src/main/java/io/xlate/edi/stream/EDIOutputFactory.java
@@ -43,6 +43,18 @@ public abstract class EDIOutputFactory extends PropertySupport {
     public static final String TRUNCATE_EMPTY_ELEMENTS = "io.xlate.edi.stream.TRUNCATE_EMPTY_ELEMENTS";
 
     /**
+     * <p>
+     * When set to true and a schema has been provided, elements written to the output will
+     * be padded to the minimum length required by the schema.
+     *
+     * <p>
+     * Default value is false.
+     *
+     * @since 1.11
+     */
+    public static final String FORMAT_ELEMENTS = "io.xlate.edi.stream.FORMAT_ELEMENTS";
+
+    /**
      * Create a new instance of the factory. This static method creates a new
      * factory instance.
      *

--- a/src/main/java/io/xlate/edi/stream/EDIStreamException.java
+++ b/src/main/java/io/xlate/edi/stream/EDIStreamException.java
@@ -37,7 +37,10 @@ public class EDIStreamException extends Exception {
      *
      * @param cause
      *            a nested exception
+     * @deprecated
      */
+    @SuppressWarnings({ "java:S1133" })
+    @Deprecated/*(forRemoval = true, since = "1.11")*/
     public EDIStreamException(Throwable cause) {
         super(cause);
         location = null;

--- a/src/test/java/io/xlate/edi/internal/stream/validation/AlphaNumericValidatorTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/validation/AlphaNumericValidatorTest.java
@@ -1,29 +1,22 @@
 package io.xlate.edi.internal.stream.validation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 
 import io.xlate.edi.internal.stream.tokenization.CharacterSet;
 import io.xlate.edi.internal.stream.tokenization.Dialect;
 import io.xlate.edi.internal.stream.tokenization.DialectFactory;
 import io.xlate.edi.internal.stream.tokenization.EDIException;
 import io.xlate.edi.schema.EDISimpleType;
-import io.xlate.edi.stream.EDIStreamException;
 import io.xlate.edi.stream.EDIStreamValidationError;
-import io.xlate.edi.stream.EDIValidationException;
 
 class AlphaNumericValidatorTest implements ValueSetTester {
 
@@ -115,8 +108,8 @@ class AlphaNumericValidatorTest implements ValueSetTester {
         when(element.getMaxLength()).thenReturn(5L);
         ElementValidator v = AlphaNumericValidator.getInstance();
         StringBuilder output = new StringBuilder();
-        EDIValidationException e = assertThrows(EDIValidationException.class, () -> v.format(dialect, element, "TESTTEST", output));
-        assertEquals(EDIStreamValidationError.DATA_ELEMENT_TOO_LONG, e.getError());
+        v.format(dialect, element, "TESTTEST", output);
+        assertHasError(v, dialect, element, output, EDIStreamValidationError.DATA_ELEMENT_TOO_LONG);
     }
 
     @Test
@@ -131,8 +124,8 @@ class AlphaNumericValidatorTest implements ValueSetTester {
         when(element.getValueSet()).thenReturn(setOf("VAL1", "VAL2"));
         ElementValidator v = AlphaNumericValidator.getInstance();
         StringBuilder output = new StringBuilder();
-        EDIValidationException e = assertThrows(EDIValidationException.class, () -> v.format(dialect, element, "TESTTEST", output));
-        assertEquals(EDIStreamValidationError.INVALID_CODE_VALUE, e.getError());
+        v.format(dialect, element, "TESTTEST", output);
+        assertHasError(v, dialect, element, output, EDIStreamValidationError.INVALID_CODE_VALUE);
     }
 
     @Test
@@ -162,12 +155,8 @@ class AlphaNumericValidatorTest implements ValueSetTester {
         when(element.getMaxLength()).thenReturn(4L);
         ElementValidator v = AlphaNumericValidator.getInstance();
         StringBuilder output = new StringBuilder();
-        try {
-            v.format(dialect, element, "TES\u0008", output);
-            fail("Exception was expected");
-        } catch (EDIException e) {
-            assertTrue(e.getMessage().startsWith("EDIE004"));
-        }
+        v.format(dialect, element, "TES\u0008", output);
+        assertHasError(v, dialect, element, output, EDIStreamValidationError.INVALID_CHARACTER_DATA);
     }
 
     @Test
@@ -183,21 +172,5 @@ class AlphaNumericValidatorTest implements ValueSetTester {
         StringBuilder output = new StringBuilder();
         v.format(dialect, element, "TEST", output);
         assertEquals("TEST      ", output.toString());
-    }
-
-    @Test
-    void testFormatValidValueIOException() throws Exception {
-        EDISimpleType element = mock(EDISimpleType.class);
-        when(element.getMinLength(anyString())).thenCallRealMethod();
-        when(element.getMaxLength(anyString())).thenCallRealMethod();
-        when(element.getValueSet(anyString())).thenCallRealMethod();
-
-        when(element.getMinLength()).thenReturn(10L);
-        when(element.getMaxLength()).thenReturn(10L);
-        ElementValidator v = AlphaNumericValidator.getInstance();
-        Appendable output = mock(Appendable.class);
-        when(output.append(ArgumentMatchers.anyChar())).thenThrow(IOException.class);
-        EDIStreamException thrown = assertThrows(EDIStreamException.class, () -> v.format(dialect, element, "TEST", output));
-        assertEquals(IOException.class, thrown.getCause().getClass());
     }
 }

--- a/src/test/java/io/xlate/edi/internal/stream/validation/DateValidatorTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/validation/DateValidatorTest.java
@@ -1,7 +1,6 @@
 package io.xlate.edi.internal.stream.validation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -19,7 +18,6 @@ import io.xlate.edi.internal.stream.tokenization.DialectFactory;
 import io.xlate.edi.internal.stream.tokenization.EDIException;
 import io.xlate.edi.schema.EDISimpleType;
 import io.xlate.edi.stream.EDIStreamValidationError;
-import io.xlate.edi.stream.EDIValidationException;
 
 class DateValidatorTest implements ValueSetTester {
 
@@ -201,8 +199,8 @@ class DateValidatorTest implements ValueSetTester {
         when(element.getMaxLength()).thenReturn(8L);
         ElementValidator v = DateValidator.getInstance();
         StringBuilder output = new StringBuilder();
-        EDIValidationException e = assertThrows(EDIValidationException.class, () -> v.format(dialect, element, "20000", output));
-        assertEquals(EDIStreamValidationError.DATA_ELEMENT_TOO_SHORT, e.getError());
+        v.format(dialect, element, "20000", output);
+        assertHasError(v, dialect, element, output, EDIStreamValidationError.DATA_ELEMENT_TOO_SHORT);
     }
 
     @Test
@@ -216,8 +214,8 @@ class DateValidatorTest implements ValueSetTester {
         when(element.getMaxLength()).thenReturn(8L);
         ElementValidator v = DateValidator.getInstance();
         StringBuilder output = new StringBuilder();
-        EDIValidationException e = assertThrows(EDIValidationException.class, () -> v.format(dialect, element, "200001011", output));
-        assertEquals(EDIStreamValidationError.DATA_ELEMENT_TOO_LONG, e.getError());
+        v.format(dialect, element, "200001011", output);
+        assertHasError(v, dialect, element, output, EDIStreamValidationError.DATA_ELEMENT_TOO_LONG);
     }
 
     @Test
@@ -231,8 +229,8 @@ class DateValidatorTest implements ValueSetTester {
         when(element.getMaxLength()).thenReturn(8L);
         ElementValidator v = DateValidator.getInstance();
         StringBuilder output = new StringBuilder();
-        EDIValidationException e = assertThrows(EDIValidationException.class, () -> v.format(dialect, element, "20000100", output));
-        assertEquals(EDIStreamValidationError.INVALID_DATE, e.getError());
+        v.format(dialect, element, "20000100", output);
+        assertHasError(v, dialect, element, output, EDIStreamValidationError.INVALID_DATE);
     }
 
     @Test

--- a/src/test/java/io/xlate/edi/internal/stream/validation/NumericValidatorTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/validation/NumericValidatorTest.java
@@ -1,7 +1,6 @@
 package io.xlate.edi.internal.stream.validation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -18,7 +17,6 @@ import io.xlate.edi.internal.stream.tokenization.DialectFactory;
 import io.xlate.edi.internal.stream.tokenization.EDIException;
 import io.xlate.edi.schema.EDISimpleType;
 import io.xlate.edi.stream.EDIStreamValidationError;
-import io.xlate.edi.stream.EDIValidationException;
 
 class NumericValidatorTest implements ValueSetTester {
 
@@ -107,8 +105,8 @@ class NumericValidatorTest implements ValueSetTester {
 
         ElementValidator v = NumericValidator.getInstance();
         StringBuilder output = new StringBuilder();
-        EDIValidationException e = assertThrows(EDIValidationException.class, () -> v.format(dialect, element, "123456", output));
-        assertEquals(EDIStreamValidationError.DATA_ELEMENT_TOO_LONG, e.getError());
+        v.format(dialect, element, "123456", output);
+        assertHasError(v, dialect, element, output, EDIStreamValidationError.DATA_ELEMENT_TOO_LONG);
     }
 
     @Test
@@ -122,8 +120,8 @@ class NumericValidatorTest implements ValueSetTester {
         when(element.getMaxLength()).thenReturn(5L);
         ElementValidator v = NumericValidator.getInstance();
         StringBuilder output = new StringBuilder();
-        EDIValidationException e = assertThrows(EDIValidationException.class, () -> v.format(dialect, element, "1234F", output));
-        assertEquals(EDIStreamValidationError.INVALID_CHARACTER_DATA, e.getError());
+        v.format(dialect, element, "1234F", output);
+        assertHasError(v, dialect, element, output, EDIStreamValidationError.INVALID_CHARACTER_DATA);
     }
 
     @Test

--- a/src/test/java/io/xlate/edi/internal/stream/validation/TimeValidatorTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/validation/TimeValidatorTest.java
@@ -2,7 +2,6 @@ package io.xlate.edi.internal.stream.validation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -20,7 +19,6 @@ import io.xlate.edi.internal.stream.tokenization.DialectFactory;
 import io.xlate.edi.internal.stream.tokenization.EDIException;
 import io.xlate.edi.schema.EDISimpleType;
 import io.xlate.edi.stream.EDIStreamValidationError;
-import io.xlate.edi.stream.EDIValidationException;
 
 class TimeValidatorTest implements ValueSetTester {
 
@@ -128,8 +126,8 @@ class TimeValidatorTest implements ValueSetTester {
         when(element.getValueSet()).thenReturn(setOf());
         ElementValidator v = TimeValidator.getInstance();
         StringBuilder output = new StringBuilder();
-        EDIValidationException e = assertThrows(EDIValidationException.class, () -> v.format(dialect, element, "1230599999", output));
-        assertEquals(EDIStreamValidationError.DATA_ELEMENT_TOO_LONG, e.getError());
+        v.format(dialect, element, "1230599999", output);
+        assertHasError(v, dialect, element, output, EDIStreamValidationError.DATA_ELEMENT_TOO_LONG);
     }
 
     @Test
@@ -144,8 +142,8 @@ class TimeValidatorTest implements ValueSetTester {
         when(element.getValueSet()).thenReturn(setOf());
         ElementValidator v = TimeValidator.getInstance();
         StringBuilder output = new StringBuilder();
-        EDIValidationException e = assertThrows(EDIValidationException.class, () -> v.format(dialect, element, "123059AA", output));
-        assertEquals(EDIStreamValidationError.INVALID_TIME, e.getError());
+        v.format(dialect, element, "123059AA", output);
+        assertHasError(v, dialect, element, output, EDIStreamValidationError.INVALID_TIME);
     }
 
     @Test

--- a/src/test/java/io/xlate/edi/internal/stream/validation/ValidatorTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/validation/ValidatorTest.java
@@ -18,7 +18,7 @@ class ValidatorTest {
     void testValidatorRootAttributes() throws EDISchemaException {
         SchemaFactory schemaFactory = SchemaFactory.newFactory();
         Schema schema = schemaFactory.getControlSchema(Standards.X12, new String[] { "00801" });
-        Validator validator = new Validator(schema, true, null);
+        Validator validator = new Validator(schema, null, true);
         EDIReference interchangeReference = validator.root.getLink();
 
         assertSame(schema.getStandard(), interchangeReference.getReferencedType());
@@ -34,7 +34,7 @@ class ValidatorTest {
     void testValidatorRootNoParent() throws EDISchemaException {
         SchemaFactory schemaFactory = SchemaFactory.newFactory();
         Schema schema = schemaFactory.getControlSchema(Standards.X12, new String[] { "00801" });
-        Validator validator = new Validator(schema, true, null);
+        Validator validator = new Validator(schema, null, true);
         UsageNode root = validator.root;
 
         assertNull(root.getParent());

--- a/src/test/java/io/xlate/edi/internal/stream/validation/ValueSetTester.java
+++ b/src/test/java/io/xlate/edi/internal/stream/validation/ValueSetTester.java
@@ -1,9 +1,17 @@
 package io.xlate.edi.internal.stream.validation;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+
+import io.xlate.edi.internal.stream.tokenization.Dialect;
+import io.xlate.edi.schema.EDISimpleType;
+import io.xlate.edi.stream.EDIStreamValidationError;
 
 interface ValueSetTester {
 
@@ -13,5 +21,11 @@ interface ValueSetTester {
 
     default Set<String> setOf(String... values) {
         return new HashSet<>(Arrays.asList(values));
+    }
+
+    default void assertHasError(ElementValidator v, Dialect dialect, EDISimpleType element, CharSequence value, EDIStreamValidationError expected) {
+        List<EDIStreamValidationError> errors = new ArrayList<>();
+        v.validate(dialect, element, value, errors);
+        assertTrue(errors.contains(expected));
     }
 }


### PR DESCRIPTION
Fixes #108 

- Requires the use of a schema and at least 1 character written to the
element (to differentiate from an empty element)
- Remove unnecessary check for validator in `UsageNode`
- Remove validation functionality from element format methods