### PR TITLE
Reset improperly positioned segment's elements in validation

### DIFF
--- a/src/main/java/io/xlate/edi/internal/stream/validation/Validator.java
+++ b/src/main/java/io/xlate/edi/internal/stream/validation/Validator.java
@@ -638,6 +638,7 @@ public class Validator {
                 handler.segmentError(next.getId(), next.getLink(), SEGMENT_NOT_IN_PROPER_SEQUENCE);
 
                 next.incrementUsage();
+                next.resetChildren();
 
                 if (next.exceedsMaximumUsage(SEGMENT_VERSION)) {
                     handler.segmentError(next.getId(), next.getLink(), SEGMENT_EXCEEDS_MAXIMUM_USE);
@@ -928,6 +929,7 @@ public class Validator {
         this.composite = this.element;
         this.element = null;
         this.composite.incrementUsage();
+        // resetChildren?
 
         if (this.composite.exceedsMaximumUsage(version)) {
             elementErrors.add(new UsageError(this.composite, TOO_MANY_REPETITIONS));
@@ -943,6 +945,7 @@ public class Validator {
 
         if (implSegmentSelected) {
             this.implComposite.incrementUsage();
+            // resetChildren?
         }
 
         return elementErrors.isEmpty();

--- a/src/test/java/io/xlate/edi/internal/stream/SegmentValidationTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/SegmentValidationTest.java
@@ -46,6 +46,7 @@ class SegmentValidationTest {
             switch (reader.getEventType()) {
             case START_TRANSACTION:
             case SEGMENT_ERROR:
+            case ELEMENT_OCCURRENCE_ERROR:
                 return true;
             default:
                 return false;


### PR DESCRIPTION
Fixes #120 

- Verified in existing test case by allowing ELEMENT_OCCURRENCE_ERROR
through filter.