### PR TITLE
Fix the escaping of the escape character; writer extends AutoClosable

### DIFF
--- a/src/main/java/io/xlate/edi/internal/stream/tokenization/CharacterSet.java
+++ b/src/main/java/io/xlate/edi/internal/stream/tokenization/CharacterSet.java
@@ -214,6 +214,7 @@ public class CharacterSet {
         case ELEMENT_REPEATER:
         case SEGMENT_DELIMITER:
         case COMPONENT_DELIMITER:
+        case RELEASE_CHARACTER:
             return true;
         default:
             return false;

--- a/src/main/java/io/xlate/edi/stream/EDIStreamWriter.java
+++ b/src/main/java/io/xlate/edi/stream/EDIStreamWriter.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import io.xlate.edi.schema.Schema;
 
-public interface EDIStreamWriter {
+public interface EDIStreamWriter extends AutoCloseable {
 
     /**
      * Get the value of a feature/property from the underlying implementation
@@ -41,6 +41,7 @@ public interface EDIStreamWriter {
      * @throws EDIStreamException
      *             if there are errors freeing associated resources
      */
+    @Override
     void close() throws EDIStreamException;
 
     /**

--- a/src/test/java/io/xlate/edi/internal/stream/StaEDIStreamWriterTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/StaEDIStreamWriterTest.java
@@ -2066,4 +2066,32 @@ class StaEDIStreamWriterTest {
         EDIStreamValidationError error = thrown.getError();
         assertEquals(EDIStreamValidationError.TOO_MANY_REPETITIONS, error);
     }
+
+    @Test
+    void testEscapeCharEscaped() throws IOException, EDIStreamException {
+        final EDIOutputFactory factory = EDIOutputFactory.newFactory();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream(4096);
+
+        try (EDIStreamWriter writer = factory.createEDIStreamWriter(stream)){
+            writer.startInterchange();
+            writer.writeStartSegment("UNB")
+                .writeStartElement()
+                    .writeComponent("UNO1")
+                    .writeComponent("1")
+                .endElement()
+                .writeEmptyElement()
+                .writeEmptyElement()
+                .writeEmptyElement()
+                .writeEmptyElement()
+                .writeEndSegment();
+
+            writer.writeStartSegment("ISA")
+                  .writeElement("???")
+                  .writeEndSegment();
+
+            writer.endInterchange();
+        }
+
+        assertEquals("UNB+UNO1:1++++'ISA+??????'", new String(stream.toByteArray()));
+    }
 }


### PR DESCRIPTION
Fixes #164 
Fixes #165 

@ronaldjmaas, thank you for the thorough issue description, solution, and test case! Your suggested change to the switch statement was perfect.