### PR TITLE
Fix for handling of alphabetic repetition separator

### DIFF
--- a/src/main/java/io/xlate/edi/internal/stream/tokenization/CharacterSet.java
+++ b/src/main/java/io/xlate/edi/internal/stream/tokenization/CharacterSet.java
@@ -236,6 +236,18 @@ public class CharacterSet {
         return getClass(character).equals(clazz);
     }
 
+    public boolean isValidDelimiter(int character) {
+        switch (getClass(character)) {
+        case CONTROL:
+            return !extraneousIgnored;
+        case WHITESPACE:
+        case OTHER:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     public static boolean isValid(int character) {
         if (character >= prototype.length) {
             return true;

--- a/src/main/java/io/xlate/edi/internal/stream/tokenization/X12Dialect.java
+++ b/src/main/java/io/xlate/edi/internal/stream/tokenization/X12Dialect.java
@@ -94,7 +94,7 @@ public class X12Dialect extends Dialect {
 
         version = new String[] { new String(header, 84, 5) };
 
-        if (numericVersion() >= RELEASE_ELEMENT_I65 && !Character.isAlphabetic(elementRepeater)) {
+        if (numericVersion() >= RELEASE_ELEMENT_I65 && characters.isValidDelimiter(elementRepeater)) {
             characters.setClass(elementRepeater, CharacterClass.ELEMENT_REPEATER);
         } else {
             /*

--- a/src/main/java/io/xlate/edi/internal/stream/tokenization/X12Dialect.java
+++ b/src/main/java/io/xlate/edi/internal/stream/tokenization/X12Dialect.java
@@ -94,6 +94,9 @@ public class X12Dialect extends Dialect {
 
         version = new String[] { new String(header, 84, 5) };
 
+        if (Character.isAlphabetic(elementRepeater)) {
+            elementRepeater = DFLT_REPETITION_SEPARATOR;
+        }
         if (numericVersion() >= RELEASE_ELEMENT_I65) {
             characters.setClass(elementRepeater, CharacterClass.ELEMENT_REPEATER);
         } else {

--- a/src/main/java/io/xlate/edi/internal/stream/tokenization/X12Dialect.java
+++ b/src/main/java/io/xlate/edi/internal/stream/tokenization/X12Dialect.java
@@ -94,10 +94,7 @@ public class X12Dialect extends Dialect {
 
         version = new String[] { new String(header, 84, 5) };
 
-        if (Character.isAlphabetic(elementRepeater)) {
-            elementRepeater = DFLT_REPETITION_SEPARATOR;
-        }
-        if (numericVersion() >= RELEASE_ELEMENT_I65) {
+        if (numericVersion() >= RELEASE_ELEMENT_I65 && !Character.isAlphabetic(elementRepeater)) {
             characters.setClass(elementRepeater, CharacterClass.ELEMENT_REPEATER);
         } else {
             /*

--- a/src/test/java/io/xlate/edi/internal/stream/StaEDIStreamReaderTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/StaEDIStreamReaderTest.java
@@ -372,8 +372,6 @@ class StaEDIStreamReaderTest implements ConstantsTest {
         expected.put(Delimiters.SEGMENT, '~');
         expected.put(Delimiters.DATA_ELEMENT, '*');
         expected.put(Delimiters.COMPONENT_ELEMENT, ':');
-        expected.put(Delimiters.REPETITION, '^');
-        //expected.put(Delimiters.RELEASE, '\\');
         expected.put(Delimiters.DECIMAL, '.');
 
         Map<String, Character> delimiters = null;


### PR DESCRIPTION
## Problem
Valid X12 ISA headers can sometimes include an alpha-numeric character at element 11. In that case, the value should be ignored in favor of the default repetition separator "^"

We've encountered real world messages that have a `V` at ISA 11 fail to parse with the following error message on later events. I'm Assuming that a `V` was encountered elsewhere in the segments and the parser assumed that it was a control character.

```
io.xlate.edi.internal.stream.tokenization.EDIException: EDIE003 - Invalid processing state; INVALID (previous: TAG_1); input: 'V' in segment AMT at position 25
	at io.xlate.edi.internal.stream.tokenization.Lexer.error(Lexer.java:432)
```

Besides the spec, there's supporting evidence for this here: https://www.ibm.com/support/pages/isa-11-repetition-separator-letter-u-and-u-character-data-it-does-not-fail-x12-deenvelope

## Fix
This change checks will `elementRepeater` to the default if the header value is alphabetic