### PR TITLE
Exception when attempting to copy an 837

### DIFF
--- a/src/main/java/io/xlate/edi/internal/stream/tokenization/State.java
+++ b/src/main/java/io/xlate/edi/internal/stream/tokenization/State.java
@@ -358,7 +358,7 @@ public enum State {
     }
 
     public boolean isHeaderState() {
-        return Category.HEADER == code;
+        return Category.HEADER == code && DialectCode.UNKNOWN != table;
     }
 
 }

--- a/src/test/java/io/xlate/edi/internal/stream/StaEDIStreamWriterTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/StaEDIStreamWriterTest.java
@@ -682,13 +682,13 @@ class StaEDIStreamWriterTest {
 
     @ParameterizedTest
     @CsvSource({
-                 "X12 837, /x12/sample837-original.edi, false",
-                 "X12 with BIN Segment, /x12/sample275_with_HL7_valid_BIN01.edi, false",
-                 "X12 with Non-ASCII Segment Terminator, /x12/issue109/ts214_ellipses_segterm.edi, false",
-                 "Basic TRADACOMS, /TRADACOMS/order.edi, false",
-                 "Basic TRADACOMS 40 Blocked, /TRADACOMS/order-blocked.edi, true",
+                 "X12 837, /x12/sample837-original.edi, false, true",
+                 "X12 with BIN Segment, /x12/sample275_with_HL7_valid_BIN01.edi, false, false",
+                 "X12 with Non-ASCII Segment Terminator, /x12/issue109/ts214_ellipses_segterm.edi, false, false",
+                 "Basic TRADACOMS, /TRADACOMS/order.edi, false, false",
+                 "Basic TRADACOMS 40 Blocked, /TRADACOMS/order-blocked.edi, true, false",
     })
-    void testInputEquivalence(String title, String resourceName, boolean blocked) throws Exception {
+    void testInputEquivalence(String title, String resourceName, boolean blocked, boolean indented) throws Exception {
         EDIInputFactory inputFactory = EDIInputFactory.newFactory();
         if (blocked) {
             inputFactory.setProperty(EDIInputFactory.EDI_IGNORE_EXTRANEOUS_CHARACTERS, "true");
@@ -716,7 +716,8 @@ class StaEDIStreamWriterTest {
         ByteArrayOutputStream result = new ByteArrayOutputStream(16384);
         writeFromReader(reader, blocked, result);
         final String expected = Stream.of(readBuffer.toString("UTF-8"))
-        	.map(StaEDITestUtil::normalizeLines)
+            .map(StaEDITestUtil::normalizeLines)
+            .map(exp -> indented ? exp.replaceAll("(?m)^\\s+", "") : exp) // Remove leading spaces in indented examples
             .map(exp -> blocked ? exp.replace("\n", "") : exp)
             .map(String::trim)
             .findFirst()

--- a/src/test/java/io/xlate/edi/internal/stream/StaEDIStreamWriterTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/StaEDIStreamWriterTest.java
@@ -682,6 +682,7 @@ class StaEDIStreamWriterTest {
 
     @ParameterizedTest
     @CsvSource({
+                 "X12 837, /x12/sample837-original.edi, false",
                  "X12 with BIN Segment, /x12/sample275_with_HL7_valid_BIN01.edi, false",
                  "X12 with Non-ASCII Segment Terminator, /x12/issue109/ts214_ellipses_segterm.edi, false",
                  "Basic TRADACOMS, /TRADACOMS/order.edi, false",


### PR DESCRIPTION
I attempted to upgrade staedi from 1.17.0 to 1.22.0 and got this exception when attempting to create a copy of an 837 transaction in a manner very similar to what's happening in `StaEDIStreamWriterTest.testInputEquivalence`.

When I add a test case using the existing sample837 it fails with the same exception that I'm seeing:

```
io.xlate.edi.stream.EDIStreamException: Invalid X12 ISA segment: too short or elements missing
 at io.xlate.edi.internal.stream.StaEDIStreamWriter.writeEndSegment(StaEDIStreamWriter.java:549)
 at io.xlate.edi.internal.stream.StaEDIStreamWriterTest.writeFromReader(StaEDIStreamWriterTest.java:757)
 at io.xlate.edi.internal.stream.StaEDIStreamWriterTest.testInputEquivalence(StaEDIStreamWriterTest.java:717)
```

I'm assuming this is some sort of regression? but please advise. Thanks!