### PR TITLE
Variable decimal mark without UNA in EDIFACT versions 1-3

### DIFF
--- a/src/main/java/io/xlate/edi/internal/stream/tokenization/Dialect.java
+++ b/src/main/java/io/xlate/edi/internal/stream/tokenization/Dialect.java
@@ -25,7 +25,7 @@ public abstract class Dialect {
     protected char segmentDelimiter;
     protected char segmentTagTerminator = '\0';
     protected char elementDelimiter;
-    protected char decimalMark;
+    protected char decimalMark = '\0';
     protected char releaseIndicator;
     protected char componentDelimiter;
     protected char elementRepeater;

--- a/src/main/java/io/xlate/edi/internal/stream/tokenization/Lexer.java
+++ b/src/main/java/io/xlate/edi/internal/stream/tokenization/Lexer.java
@@ -247,7 +247,7 @@ public class Lexer {
                 break;
             case HEADER_DATA:
             case HEADER_INVALID_DATA:
-                handleStateHeaderData(input);
+                handleStateHeaderData((char) input);
                 eventsReady = dialectConfirmed(State.TAG_SEARCH);
                 break;
             case HEADER_SEGMENT_BEGIN:
@@ -397,8 +397,8 @@ public class Lexer {
         openSegment();
     }
 
-    void handleStateHeaderData(int input) throws EDIException {
-        dialect.appendHeader(characters, (char) input);
+    void handleStateHeaderData(char input) throws EDIException {
+        dialect.appendHeader(characters, input);
 
         switch (characters.getClass(input)) {
         case SEGMENT_DELIMITER:
@@ -412,8 +412,8 @@ public class Lexer {
         case RELEASE_CHARACTER:
             break;
         default:
-            if (dialect.getDecimalMark() != input && !characters.isIgnored(input)) {
-                buffer.put((char) input);
+            if (!dialect.isDecimalMark(input) && !characters.isIgnored(input)) {
+                buffer.put(input);
             }
             break;
         }

--- a/src/main/java/io/xlate/edi/internal/stream/tokenization/TradacomsDialect.java
+++ b/src/main/java/io/xlate/edi/internal/stream/tokenization/TradacomsDialect.java
@@ -41,7 +41,6 @@ public class TradacomsDialect extends Dialect {
         super(State.DialectCode.TRADACOMS, new String[1]);
         componentDelimiter = DFLT_COMPONENT_ELEMENT_SEPARATOR;
         elementDelimiter = DFLT_DATA_ELEMENT_SEPARATOR;
-        decimalMark = 0;
         releaseIndicator = DFLT_RELEASE_CHARACTER;
         elementRepeater = 0;
         segmentDelimiter = DFLT_SEGMENT_TERMINATOR;

--- a/src/test/java/io/xlate/edi/internal/stream/StaEDIStreamWriterTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/StaEDIStreamWriterTest.java
@@ -18,6 +18,7 @@ package io.xlate.edi.internal.stream;
 import static io.xlate.edi.test.StaEDITestUtil.normalizeLines;
 import static io.xlate.edi.test.StaEDITestUtil.write;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -1864,7 +1865,7 @@ class StaEDIStreamWriterTest {
         assertEquals(':', delimiters.get(Delimiters.COMPONENT_ELEMENT));
         assertEquals('.', delimiters.get(Delimiters.DECIMAL));
         assertEquals('?', delimiters.get(Delimiters.RELEASE));
-        assertNull(delimiters.get(Delimiters.REPETITION)); // Not introduced until v4
+        assertFalse(delimiters.containsKey(Delimiters.REPETITION)); // Not introduced until v4
 
         writer.flush();
         assertEquals("UNB+UNOA:3+005435656:1+006415160:1+060515:1434+00000000000778'",
@@ -1910,8 +1911,8 @@ class StaEDIStreamWriterTest {
         assertEquals('+', delimiters.get(Delimiters.DATA_ELEMENT));
         assertEquals(':', delimiters.get(Delimiters.COMPONENT_ELEMENT));
         assertEquals('.', delimiters.get(Delimiters.DECIMAL));
-        assertNull(delimiters.get(Delimiters.RELEASE));
-        assertNull(delimiters.get(Delimiters.REPETITION)); // Not introduced until v4
+        assertFalse(delimiters.containsKey(Delimiters.RELEASE));
+        assertFalse(delimiters.containsKey(Delimiters.REPETITION)); // Not introduced until v4
 
         writer.flush();
         assertEquals("UNA:+.  'UNB+UNOA:3+005435656:1+006415160:1+060515:1434+00000000000778'",

--- a/src/test/java/io/xlate/edi/internal/stream/tokenization/EDIFACTDialectTest.java
+++ b/src/test/java/io/xlate/edi/internal/stream/tokenization/EDIFACTDialectTest.java
@@ -91,7 +91,7 @@ class EDIFACTDialectTest {
         assertEquals('\'', edifact.getSegmentTerminator());
         assertEquals('+', edifact.getDataElementSeparator());
         assertEquals(':', edifact.getComponentElementSeparator());
-        assertEquals('.', edifact.getDecimalMark());
+        assertEquals('.', edifact.getDecimalMark()); // UNA value ignored, per spec
         assertEquals('*', edifact.getRepetitionSeparator());
         assertEquals(' ', edifact.getReleaseIndicator());
     }


### PR DESCRIPTION
Allow either `,` or `.` when no EDIFACT `UNA` segment received prior to version 4

Fixes #406 