### PR TITLE
Make transaction metadata available between begin/end transaction events

### DIFF
--- a/src/main/java/io/xlate/edi/internal/stream/StaEDIStreamReader.java
+++ b/src/main/java/io/xlate/edi/internal/stream/StaEDIStreamReader.java
@@ -210,12 +210,14 @@ public class StaEDIStreamReader implements EDIStreamReader, Configurable, Valida
 
         if (!proxy.nextEvent()) {
             proxy.resetEvents();
-            executeTask(lexer::parse, "Error parsing input");
+            do {
+                executeTask(lexer::parse, "Error parsing input");
+            } while (proxy.additionalEventsRequired());
         }
 
         final EDIStreamEvent event = proxy.getEvent();
 
-        LOGGER.finer(() -> "EDI event: " + event);
+        LOGGER.finer(() -> "EDI event: " + event + (event.isError() ? "; error type: " + proxy.getErrorType(): ""));
 
         if (event == EDIStreamEvent.END_INTERCHANGE) {
             executeTask(() -> complete = !proxy.hasNext() && !lexer.hasRemaining(), "Error reading input");

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -2,6 +2,6 @@
 handlers=java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level=FINEST
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] [%4$-7s] %5$s %n
+java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] [%4$-7s] %3$s %5$s %n
 
 io.xlate.edi.level=FINER


### PR DESCRIPTION
Closes #532 

Update the stream reader to enqueue the entire transaction header segment so that client applications have access to transaction type and an accurate transaction version starting with the `START_TRANSACTION` event and through (including) the `END_TRANSACTION` event.