### PR TITLE
Increase element buffer capacity to 1000 (closes #624)

### DIFF
--- a/src/main/java/io/xlate/edi/internal/stream/StaEDIStreamWriter.java
+++ b/src/main/java/io/xlate/edi/internal/stream/StaEDIStreamWriter.java
@@ -95,7 +95,7 @@ public class StaEDIStreamWriter implements EDIStreamWriter, ElementDataHandler, 
     private Validator transactionValidator;
     private CharArraySequence dataHolder = new CharArraySequence();
     private boolean atomicElementWrite = false;
-    private CharBuffer elementBuffer = CharBuffer.allocate(500);
+    private CharBuffer elementBuffer = CharBuffer.allocate(1000);
     private final StringBuilder formattedElement = new StringBuilder();
     private List<EDIValidationException> errors = new ArrayList<>();
     private CharArraySequence elementHolder = new CharArraySequence();


### PR DESCRIPTION
Summary
                                                                                                                                                                                                                                                                
  Increases the EDIStreamWriter element buffer capacity from 500 to 1000 characters.
                                                                                                                                                                                                                                                                
  Resolves #.
                                                                                                                                                                                                                                                                
  Problem

  StaEDIStreamWriter allocated elementBuffer with a fixed capacity of 500 characters and never resized it. Writing any single element longer than 500 characters threw a java.nio.BufferOverflowException (with no message), even for values that are valid per 
  the EDI standard — e.g. X12 element 1551 (MTX02, Free-Form Message Text) permits up to 4096 characters. The buffer is also populated regardless of whether a transaction schema is set, so the limit affected all element writes.
                                                                                                                                                                                                                                                                
  Change

  - StaEDIStreamWriter.java: elementBuffer = CharBuffer.allocate(500) → CharBuffer.allocate(1000).                                                                                                                                                              
         
  This is the value agreed on in #624. The increase is a small, one-time per-writer allocation (~2 KB) with no behavioral change other than allowing longer elements to be written.
---
  A couple of notes:
  - I scoped this to only elementBuffer (the buffer that caused the overflow). I left unconfirmedBuffer untouched since it only buffers the fixed-length interchange header and never approaches the limit — keeping the diff minimal for review.